### PR TITLE
feat(pulls): Enhance PR data from PR Detail Endpoint Information

### DIFF
--- a/tap_github/schemas/pull_requests.json
+++ b/tap_github/schemas/pull_requests.json
@@ -509,6 +509,38 @@
         },
         "ref": {
           "type": ["null", "string"]
+        },
+        "repo": {
+          "type": ["null", "object"],
+          "properties": {
+            "id": {
+              "type": ["null", "integer"]
+            },
+            "name": {
+              "type": ["null", "string"]
+            },
+            "full_name": {
+              "type": ["null", "string"]
+            },
+            "size": {
+              "type": ["null", "integer"]
+            },
+            "default_branch": {
+              "type": ["null", "integer"]
+            },
+            "pushed_at": {
+              "type": ["null", "integer"],
+              "format": "date-time"
+            },
+            "created_at": {
+              "type": ["null", "integer"],
+              "format": "date-time"
+            },
+            "updated_at": {
+              "type": ["null", "integer"],
+              "format": "date-time"
+            }
+          }
         }
       }
     },
@@ -540,19 +572,19 @@
       "type": ["null", "string"]
     },
     "auto_merge": {
-      "type": ["null", "string"]
+      "type": ["null", "boolean"]
     },
     "draft": {
-      "type": ["null", "string"]
+      "type": ["null", "boolean"]
     },
     "merged": {
-      "type": ["null", "string"]
+      "type": ["null", "boolean"]
     },
     "mergeable": {
-      "type": ["null", "string"]
+      "type": ["null", "boolean"]
     },
     "rebaseable": {
-      "type": ["null", "string"]
+      "type": ["null", "boolean"]
     },
     "mergeable_state": {
       "type": ["null", "string"]

--- a/tap_github/schemas/pull_requests.json
+++ b/tap_github/schemas/pull_requests.json
@@ -526,7 +526,7 @@
               "type": ["null", "integer"]
             },
             "default_branch": {
-              "type": ["null", "integer"]
+              "type": ["null", "string"]
             },
             "pushed_at": {
               "type": ["null", "string"],

--- a/tap_github/schemas/pull_requests.json
+++ b/tap_github/schemas/pull_requests.json
@@ -529,15 +529,15 @@
               "type": ["null", "integer"]
             },
             "pushed_at": {
-              "type": ["null", "integer"],
+              "type": ["null", "string"],
               "format": "date-time"
             },
             "created_at": {
-              "type": ["null", "integer"],
+              "type": ["null", "string"],
               "format": "date-time"
             },
             "updated_at": {
-              "type": ["null", "integer"],
+              "type": ["null", "string"],
               "format": "date-time"
             }
           }


### PR DESCRIPTION
I want to try to enhance the data from Pull Requests using the Github API detail endpoint:

https://docs.github.com/en/rest/reference/pulls#get-a-pull-request

Right now the fields like additions, deletions, comments, base, head, etc. are null because this info is not returned in the Github list pull request endpoint.
