### PR TITLE
feat(reviews): Add pull request id to review schema

### DIFF
--- a/tap_github/schemas/reviews.json
+++ b/tap_github/schemas/reviews.json
@@ -36,7 +36,7 @@
       "type": ["null", "integer"]
     },
     "pull_request_id": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "pull_request_url": {
       "type": ["null", "string"]


### PR DESCRIPTION
Github PR Id is a string (character varying)

We need the PR Id in order to be able to join Reviews with each pull request unequivocally. PR number is not working for this goal because is not unique, it depends on the repository.