### PR TITLE
feat(workflow_runs): Add head commit author email

### DIFF
--- a/tap_github/actions/workflow_runs.py
+++ b/tap_github/actions/workflow_runs.py
@@ -71,8 +71,9 @@ def get_commit_detail(repo_path, commit_id):
 def enhance_workflow_run_with_commit_info(run, repo_path):
     commit_id = run["head_commit"]["id"]
     commit = get_commit_detail(repo_path, commit_id)
-    run["head_commit_author_id"] = commit["author"]["id"]
-    run["head_commit_author_login"] = commit["author"]["login"]
+    run["head_commit_author_id"] = commit["author"]["id"] if commit["author"] else ""
+    run["head_commit_author_login"] = commit["author"]["login"] if commit["author"] else ""
+    run["head_commit_author_email"] = commit["commit"]["author"]["email"] if commit["commit"] else ""
     return run
 
 

--- a/tap_github/schemas/workflow_runs.json
+++ b/tap_github/schemas/workflow_runs.json
@@ -46,6 +46,12 @@
         "string"
       ]
     },
+    "head_commit_author_email": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "run_number": {
       "type": [
         "null",


### PR DESCRIPTION
We need this information because if you delete an email from GitHub, GitHub API does not return the author field into the commit detail. We want to store the author's email in order to be able to indicate what runs were initiated by what user.

